### PR TITLE
Bugfix wildcard & @2x filenames

### DIFF
--- a/lib/Balancer.js
+++ b/lib/Balancer.js
@@ -113,16 +113,24 @@ Balancer.prototype.handleNodeUnregister = function(req, res) {
 Balancer.prototype.handleProxyRequest = function(req, res, next) {
 	// /:layer/:z/:x/:y/:file?qs
 	var parts = req.url.substring(1).split('/');
-	if (parts.length < 5) return next();
+	if (parts.length < 4) return next();
 	var layer = parts[0];
 	var z = Number(parts[1]);
 	var x = Number(parts[2]);
-	var y = Number(parts[3]);
+	var y;
+	var file;
+	if (parts[3].includes('.')) {
+		var fileNamePart = parts[3].split('.');
+		y = parseInt(fileNamePart[0]);
+		file = '*' + fileNamePart[0].substring(y.toString().length) + '.' + fileNamePart[1];
+	} else {
+		y = parseInt(parts[3]);
+		file = parts[4];
+	}
 	if (isNaN(x) || isNaN(y) || isNaN(z)) {
 		return next();
 	}
 
-	var file = parts[4];
 	var qspos = file.indexOf('?');
 	if (qspos > -1) file = file.substring(0, qspos);
 	if (!file) return next();

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "chai": "^3.3.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "tilestrata": "^2.1.3"
   }
 }


### PR DESCRIPTION
Bugfix / feature enhancement to add support for "routing without filenames" just as it was added in tilestrata v2.1.0. Also added devDependency that was needed by tests. No new tests added.

I'm using tilestrata-server & number of its plug-ins actively and have small bug fixes here and there also for those + a new module tilestrata-overzoom. Happy to make PRs for those too if contributions are welcome.